### PR TITLE
Add tolerance option

### DIFF
--- a/jquery.simulate.drag-sortable.js
+++ b/jquery.simulate.drag-sortable.js
@@ -9,6 +9,7 @@
    * - handle: selector for the draggable handle element (optional)
    * - listItem: selector to limit which sibling items can be used for reordering
    * - placeHolder: if a placeholder is used during dragging, we need to consider it's height
+   * - tolerance: 'intersect' if draggable must overlap the droppable at least 50%, otherwise 'pointer'
    *
    */
   $.fn.simulateDragSortable = function(options) {
@@ -26,6 +27,7 @@
           moveCounter = Math.floor(opts.move),
           direction = moveCounter > 0 ? 'down' : 'up',
           moveVerticalAmount = 0,
+          extraDrag = (opts.tolerance === 'intersect') ? $(this).outerHeight() / 2 : 1,
           dragPastBy = 0;
 
       if (moveCounter === 0) { return; }
@@ -51,15 +53,16 @@
       dispatchEvent(handle, 'mousedown', createEvent('mousedown', handle, { clientX: x, clientY: y }));
       // simulate drag start
       dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x+1, clientY: y+1 }));
-
+      
       // Sortable is using a fixed height placeholder meaning items jump up and down as you drag variable height items into fixed height placeholder
       placeHolder = placeHolder && $(this).parent().find(placeHolder);
+
       if (placeHolder && placeHolder.length) {
         // we're going to move past it, and back again
-        moveVerticalAmount += (direction === 'down' ? -1 : 1) * Math.min($(this).outerHeight() / 2, 5);
+        moveVerticalAmount += (direction === 'down' ? -1 : 1) * Math.min(extraDrag, 5);
         // Sortable UI bug when dragging down and place holder exists.  You need to drag past by the total height of this
         //  and then drag back to the right point
-        dragPastBy = (direction === 'down' ? 1 : -1) * $(this).outerHeight() / 2;
+        dragPastBy = (direction === 'down' ? 1 : -1) * extraDrag;
       } else {
         // no place holder
         if (direction === 'down') {
@@ -67,10 +70,10 @@
           if ($(this).outerHeight() > $(sibling).outerHeight()) {
             moveVerticalAmount += $(this).outerHeight() - $(sibling).outerHeight();
           }
-          moveVerticalAmount += $(sibling).outerHeight() / 2;
+          moveVerticalAmount += extraDrag;
         } else {
           // move a little extra to ensure item clips into next position
-          moveVerticalAmount -= Math.min($(this).outerHeight() / 2, 5);
+          moveVerticalAmount -= Math.min(extraDrag, 5);
         }
       }
 
@@ -158,6 +161,7 @@
   // plugin defaults
   //
   $.fn.simulateDragSortable.defaults = {
-    move: 0
+    move: 0,
+    tolerance: 'intersect'
   };
 })(jQuery);


### PR DESCRIPTION
The current code drags the element too far when using the 'pointer' tolerance option in sortable. This pull request adds a 'tolerance' option to compensate for this.
